### PR TITLE
update react-native-keychain

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.17.5",
     "react-move": "^2.7.0",
     "react-native-easy-grid": "^0.2.2",
-    "react-native-keychain": "^5.0.1",
+    "react-native-keychain": "^6.1.1",
     "react-native-touch-id": "^4.4.1",
     "react-native-vector-icons": "^6.6.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4846,10 +4846,10 @@ react-native-easy-grid@^0.2.2:
   dependencies:
     lodash "^4.17.15"
 
-react-native-keychain@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-5.0.1.tgz#2751de436f017c87b8aabb32533bee88657d643e"
-  integrity sha512-CLIPNexPBufPpNqgF7/smZNAiv6x0SCsztfEi/hWPCQ7yHxNwdRUyUzOLGrw1lPe/6fQE+TC3iS1+cbDTaRJag==
+react-native-keychain@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-6.1.1.tgz#3c14e4df9e5599f8d5a708da75d27f9d2424d7c1"
+  integrity sha512-WYvAg7FbYPyX8jJ1rY/IQGS+6zK5LtNMRa3E8x1n0M5Lmsm/9CHtakzbmqT+rLvFE7DpPBg7qFawMuUoDjjtYA==
 
 react-native-touch-id@^4.4.1:
   version "4.4.1"


### PR DESCRIPTION
Update this keychain library will fix this issue [PinCodeEnter:  [Error: Title must be set and non-empty]](https://github.com/jarden-digital/react-native-pincode/issues/137)